### PR TITLE
URL Cleanup

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/spring-data-neo4j/src/main/resources/org/springframework/data/neo4j/config/datagraph-1.0.xsd
+++ b/spring-data-neo4j/src/main/resources/org/springframework/data/neo4j/config/datagraph-1.0.xsd
@@ -12,7 +12,7 @@
     <xsd:import namespace="http://www.springframework.org/schema/tool"/>
     <xsd:import namespace="http://www.springframework.org/schema/beans"/>
     <xsd:import namespace="http://www.springframework.org/schema/data/repository"
-                schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
+                schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
 
    <xsd:element name="config">
       <xsd:complexType>

--- a/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/NodeEntityTest.java
+++ b/spring-data-neo4j/src/test/java/org/springframework/data/neo4j/support/NodeEntityTest.java
@@ -103,7 +103,7 @@ import static org.springframework.data.neo4j.Person.persistedPerson;
         group.setName("developers");
         assertEquals("developers", group.getPersistentState().getProperty("name"));
     }
-    // own transaction handling because of http://wiki.neo4j.org/content/Delete_Semantics
+    // own transaction handling because of https://neo4j.com/docs/
     @Test(expected = NotFoundException.class)
     public void testDeleteEntityFromGDC() {
         Transaction tx = graphDatabaseContext.beginTx();

--- a/src/docbkx/resources/xsl/highlight-fo.xsl
+++ b/src/docbkx/resources/xsl/highlight-fo.xsl
@@ -5,7 +5,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbkx/resources/xsl/highlight.xsl
+++ b/src/docbkx/resources/xsl/highlight.xsl
@@ -3,7 +3,7 @@
     Simple highlighter for HTML output. Follows the Eclipse color scheme.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/src/docbkx/resources/xsl/html/html_chunk.xsl
+++ b/src/docbkx/resources/xsl/html/html_chunk.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 
@@ -109,7 +109,7 @@
 	<xsl:template name="user.head.content">
 		<xsl:comment>Begin Google Analytics code</xsl:comment>
 		<script type="text/javascript">
-			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+			var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www.");
 			document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
 		</script>
 		<script type="text/javascript">

--- a/src/docbkx/resources/xsl/html_chunk.xsl
+++ b/src/docbkx/resources/xsl/html_chunk.xsl
@@ -75,11 +75,11 @@
     <!-- let's have a Spring and SpringSource banner across the top of each page -->
     <xsl:template name="user.header.navigation">
         <div style="background-color:white;border:none;height:73px;border:1px solid black;">
-            <a style="border:none;" href="http://static.springframework.org/spring-ws/site/"
+            <a style="border:none;" href="https://docs.spring.io/spring-ws/site/"
                title="The Spring Framework - Spring Web Services">
                 <img style="border:none;" src="images/xdev-spring_logo.jpg"/>
             </a>
-            <a style="border:none;" href="http://www.springsource.com/" title="SpringSource">
+            <a style="border:none;" href="https://www.springsource.com/" title="SpringSource">
                 <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/s2_box_logo.png"/>
             </a>
         </div>
@@ -189,7 +189,7 @@
                                 </td>
                                 <td width="20%" align="center">
                                     <span style="color:white;font-size:90%;">
-                                        <a href="http://www.springsource.com/"
+                                        <a href="https://www.springsource.com/"
                                            title="SpringSource">Sponsored by SpringSource
                                         </a>
                                     </span>

--- a/src/docbkx/resources/xsl/pdf/fopdf.xsl
+++ b/src/docbkx/resources/xsl/pdf/fopdf.xsl
@@ -21,7 +21,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				exclude-result-prefixes="xslthl"
 				version='1.0'>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://jotm.objectweb.org (200) with 1 occurrences could not be migrated:  
   ([https](https://jotm.objectweb.org) result NotSslRecordException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://loopfuse.net/webrecorder/js/listen.js (404) with 1 occurrences could not be migrated:  
   ([https](https://loopfuse.net/webrecorder/js/listen.js) result SSLHandshakeException).
* [ ] http://xapool.experlog.com (404) with 1 occurrences could not be migrated:  
   ([https](https://xapool.experlog.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www (UnknownHostException) with 1 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springframework.org/spring-ws/site/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/site/ ([https](https://static.springframework.org/spring-ws/site/) result 200).
* [ ] http://wiki.neo4j.org/content/Delete_Semantics (301) with 1 occurrences migrated to:  
  https://neo4j.com/docs/ ([https](https://wiki.neo4j.org/content/Delete_Semantics) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* [ ] http://www.springsource.com/ with 2 occurrences migrated to:  
  https://www.springsource.com/ ([https](https://www.springsource.com/) result 301).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://localhost:7473/test/ with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/data/graph with 2 occurrences
* http://www.springframework.org/schema/data/repository with 2 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 7 occurrences
* http://www.w3.org/1999/XSL/Transform with 7 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences